### PR TITLE
Fix blocking pool + adding stress test + closing response.

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -16,6 +16,8 @@ func main() {
 	pflag.String("elk-user", "", "Username with create access on the correct Elastic Index")
 	pflag.String("elk-pass", "", "Password for provided user")
 	pflag.Int("log-level", int(logging.INFO), "set the log level to display")
+	pflag.Int("processes", 0, "how many processes to use")
+	pflag.Bool("stress-test", false, "if to perform some stress test (send a shit ton of logs to elastic search)")
 
 	pflag.Parse()
 
@@ -34,13 +36,22 @@ func main() {
 	logging.LogAs(logging.FATAL, "Hello fatal!")
 	logging.Info("More logging!")
 
+	if viper.GetBool("stress-test") {
+		for i := 0; i < 1000; i++ {
+			time.Sleep(1)
+			logging.Info("Sending stress test logs!!")
+
+		}
+
+	}
+
 	fmt.Println("Sent all log messages to elasticsearch:", time.Since(now))
 }
 
 // This function *must* run before any calls to logging package
 func setUpElasticClient() {
 	if err := logging.SetElasticClient(
-		0,
+		viper.GetInt("processes"),
 		viper.GetString("elk-service"),
 		elasticsearch.Config{
 			Addresses: []string{viper.GetString("elk-cloud-addr")},

--- a/example/main.go
+++ b/example/main.go
@@ -38,7 +38,6 @@ func main() {
 
 	if viper.GetBool("stress-test") {
 		for i := 0; i < 1000; i++ {
-			time.Sleep(1)
 			logging.Info("Sending stress test logs!!")
 
 		}

--- a/pkg/logging/.gitignore
+++ b/pkg/logging/.gitignore
@@ -1,0 +1,1 @@
+esconfig.json

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -74,16 +74,16 @@ func getIntOrDefault(i, defaultInt int) int {
 func sendToElasticServer(event LogLine) {
 	logJSON, err := json.Marshal(event)
 	if err != nil {
-		Errf(err.Error())
+		log.Printf("got an error while marshling event to json: %v", err)
 		return
 	}
 	res, err := esClient.Index(customerIndex, bytes.NewReader(logJSON))
 	if err != nil {
-		Errf("Error sending logs to esl. error in the response: %v", err)
+		log.Printf("got an error while sending log to elastic search: %v", err)
 		return
 	}
 	if res.IsError() {
-		Errf("Response was error: %v", res.String())
+		log.Printf("got an error response after sending logs to elastic search. response was: %v", res)
 		return
 	}
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -84,7 +84,6 @@ func sendToElasticServer(event LogLine) {
 	}
 	if res.IsError() {
 		log.Printf("got an error response after sending logs to elastic search. response was: %v", res)
-		return
 	}
 	res.Body.Close()
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -86,6 +86,7 @@ func sendToElasticServer(event LogLine) {
 		log.Printf("got an error response after sending logs to elastic search. response was: %v", res)
 		return
 	}
+	res.Body.Close()
 }
 
 // evaluate if we have all the flags needed to setup the elastic search client.

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -57,17 +57,3 @@ func TestNonBlocking(t *testing.T) {
 
 	}
 }
-
-//func TestMissingConfigs(t *testing.T) {
-//
-//	err := SetElasticClient(
-//		0,
-//		"bla",
-//		elasticsearch.Config{
-//			Addresses: []string{"test"},
-//		},
-//	)
-//
-//	Info("Hello info!")
-//
-//}

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -39,8 +39,9 @@ func TestNonBlocking(t *testing.T) {
 
 	config := readESConfigs("esconfig.json")
 
+	// use too many processes on purpouse to get some errors back
 	err := SetElasticClient(
-		0,
+		1000,
 		"test",
 		elasticsearch.Config{
 			Addresses: []string{config["elk-cloud-addr"]},

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -13,7 +13,6 @@ func readESConfigs(path string) map[string]string {
 	var config map[string]string
 
 	jsonFile, err := os.Open(path)
-	// if we os.Open returns an error then handle it
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -1,0 +1,73 @@
+package logging
+
+import (
+	"encoding/json"
+	"github.com/elastic/go-elasticsearch/v8"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func readESConfigs(path string) map[string]string {
+
+	var config map[string]string
+
+	jsonFile, err := os.Open(path)
+	// if we os.Open returns an error then handle it
+	if err != nil {
+		panic(err)
+	}
+	defer jsonFile.Close()
+
+	byteValue, err := ioutil.ReadAll(jsonFile)
+
+	if err != nil {
+		panic(err)
+	}
+
+	err = json.Unmarshal(byteValue, &config)
+	if err != nil {
+		panic(err)
+	}
+
+	return config
+}
+
+// make sure we can call a bunch of logs
+// without the program blocking execution
+func TestNonBlocking(t *testing.T) {
+
+	config := readESConfigs("esconfig.json")
+
+	err := SetElasticClient(
+		0,
+		"test",
+		elasticsearch.Config{
+			Addresses: []string{config["elk-cloud-addr"]},
+			Username:  config["elk-user"],
+			Password:  config["elk-pass"],
+		})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 1000; i++ {
+		Info("Sending stress test logs!!")
+
+	}
+}
+
+//func TestMissingConfigs(t *testing.T) {
+//
+//	err := SetElasticClient(
+//		0,
+//		"bla",
+//		elasticsearch.Config{
+//			Addresses: []string{"test"},
+//		},
+//	)
+//
+//	Info("Hello info!")
+//
+//}


### PR DESCRIPTION
This fixes the infinite calls to elastic search.

Before, if we had a response that was an error we would call `Errf`, whic would call `Log`, which would call `sendToElasticServer` again, creating an infinite loop and blocking the program execution.